### PR TITLE
Add --help flag and GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Build & Release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Build binaries
+        run: |
+          VERSION=${{ github.ref_name }}
+          LDFLAGS="-s -w -X main.version=${VERSION}"
+
+          GOOS=darwin  GOARCH=amd64 go build -trimpath -ldflags "${LDFLAGS}" -o spotify-garden-darwin-amd64  .
+          GOOS=darwin  GOARCH=arm64 go build -trimpath -ldflags "${LDFLAGS}" -o spotify-garden-darwin-arm64  .
+          GOOS=linux   GOARCH=amd64 go build -trimpath -ldflags "${LDFLAGS}" -o spotify-garden-linux-amd64   .
+          GOOS=linux   GOARCH=arm64 go build -trimpath -ldflags "${LDFLAGS}" -o spotify-garden-linux-arm64   .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            spotify-garden-darwin-amd64
+            spotify-garden-darwin-arm64
+            spotify-garden-linux-amd64
+            spotify-garden-linux-arm64

--- a/main.go
+++ b/main.go
@@ -16,6 +16,9 @@ import (
 	"github.com/benstraw/spotify-garden/internal/render"
 )
 
+// version is set at build time via -ldflags "-X main.version=vX.Y.Z"
+var version = "dev"
+
 const playsFile = "data/plays.json"
 
 func main() {
@@ -40,6 +43,11 @@ func main() {
 		runCatchUp(args)
 	case "persona":
 		runPersona()
+	case "version", "--version":
+		fmt.Println("spotify-garden", version)
+	case "help", "--help", "-h":
+		printUsage()
+		os.Exit(0)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", cmd)
 		printUsage()
@@ -48,7 +56,7 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Print(`spotify-garden — Spotify listening data → Obsidian markdown
+	fmt.Printf(`spotify-garden %s — Spotify listening data → Obsidian markdown
 
 Usage:
   spotify-garden auth                       Authenticate with Spotify via OAuth
@@ -56,11 +64,12 @@ Usage:
   spotify-garden weekly [--date YYYY-MM-DD] Generate weekly note for date's ISO week (default: current)
   spotify-garden catch-up [--weeks N]       Generate missing weekly notes (default: 8 weeks back)
   spotify-garden persona                    Regenerate Music Taste context pack
+  spotify-garden version                    Print version
 
 Flags:
   --date   Date in YYYY-MM-DD format (default: today)
   --weeks  Number of weeks to check (default: 8)
-`)
+`, version)
 }
 
 // loadDotEnv reads a .env file and sets environment variables.


### PR DESCRIPTION
- Add help/--help/-h top-level command that prints usage and exits 0
- Add version/--version command that prints the version string
- Add var version = "dev" embedded at build time via -ldflags "-X main.version=vX.Y.Z"
- printUsage() now includes the version string in the header line
- Add .github/workflows/release.yml: triggers on v* tags, builds stripped
  binaries for darwin/amd64, darwin/arm64, linux/amd64, linux/arm64,
  embeds tag as version, and publishes a GitHub Release with auto-generated
  release notes via softprops/action-gh-release

https://claude.ai/code/session_014D7gCTX5jsHNHd6yM5mzLW